### PR TITLE
Improve German H1

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -6,7 +6,7 @@
     "ogTitle": "Ellie - Ihr AI-E-Mail-Assistent"
   },
   "hero": {
-    "title": "Lernen Sie Ellie kennen, Ihren AI-E-Mail-Assistenten",
+    "title": "Ellie, Ihr E-Mail-Assistent mit künstlicher Intelligenz",
     "description": "Ellie lernt aus Ihrem Schreibstil und formuliert Antworten, als ob sie von Ihnen geschrieben wurden"
   },
   "stats": {


### PR DESCRIPTION
This gets rid of the word "Meet" for which there is no good German translation.

It also spells out "AI" because almost no Germans know that acronym (only tech people). I'm also not sure how many Germans know the translated acronym "KI". Spelling it out also makes the H1 sound more friendly to match the English "Meet" phrase.